### PR TITLE
Support more authentication methods

### DIFF
--- a/aliyunstoreplugin/store/artifact/aliyun_oss_artifact_repo.py
+++ b/aliyunstoreplugin/store/artifact/aliyun_oss_artifact_repo.py
@@ -1,12 +1,26 @@
 import os
-
 import posixpath
-from six.moves import urllib
 
+import oss2
+from alibabacloud_credentials.client import Client
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import relative_path_to_artifact_path
+from oss2 import CredentialsProvider
+from oss2.credentials import Credentials
+from six.moves import urllib
+
+
+class CredentialProviderWrapper(CredentialsProvider):
+    def __init__(self, client):
+        self.client = client
+
+    def get_credentials(self):
+        access_key_id = self.client.get_access_key_id()
+        access_key_secret = self.client.get_access_key_secret()
+        security_token = self.client.get_security_token()
+        return Credentials(access_key_id, access_key_secret, security_token)
 
 
 class AliyunOssArtifactRepository(ArtifactRepository):
@@ -19,14 +33,24 @@ class AliyunOssArtifactRepository(ArtifactRepository):
             self.oss_bucket = oss_bucket
             return
 
-        import oss2
-        self.oss_endpoint_url = os.environ.get('MLFLOW_OSS_ENDPOINT_URL')
-        oss_access_key_id = os.environ.get('MLFLOW_OSS_KEY_ID')
-        oss_access_key_secret = os.environ.get('MLFLOW_OSS_KEY_SECRET')
-        assert self.oss_endpoint_url, 'please set MLFLOW_OSS_ENDPOINT_URL'
-        assert oss_access_key_id, 'please set MLFLOW_OSS_KEY_ID'
-        assert oss_access_key_secret, 'please set MLFLOW_OSS_KEY_SECRET'
-        self.auth = oss2.Auth(oss_access_key_id, oss_access_key_secret)
+        self.auth = None
+        self.oss_endpoint_url = os.environ.get("MLFLOW_OSS_ENDPOINT_URL")
+        assert self.oss_endpoint_url, "please set MLFLOW_OSS_ENDPOINT_URL"
+        oss_access_key_id = os.environ.get("MLFLOW_OSS_KEY_ID")
+        oss_access_key_secret = os.environ.get("MLFLOW_OSS_KEY_SECRET")
+        if oss_access_key_id and oss_access_key_secret:
+            self.auth = oss2.Auth(oss_access_key_id, oss_access_key_secret)
+        else:
+            try:
+                cred = Client()
+                credentials_provider = CredentialProviderWrapper(cred)
+                self.auth = oss2.ProviderAuth(credentials_provider)
+            except Exception:
+                pass
+        assert (
+            self.auth
+        ), "please set MLFLOW_OSS_KEY_ID and MLFLOW_OSS_KEY_SECRET environment variable, or you can refer https://pypi.org/project/alibabacloud-credentials for how to use the default credential provider"
+
         self.oss_bucket = None
         self.is_plugin = True
 
@@ -37,12 +61,11 @@ class AliyunOssArtifactRepository(ArtifactRepository):
         if parsed.scheme != "oss":
             raise Exception("Not an OSS URI: %s" % uri)
         path = parsed.path
-        if path.startswith('/'):
+        if path.startswith("/"):
             path = path[1:]
         return parsed.netloc, path
 
     def _get_oss_bucket(self, bucket):
-        import oss2
         if self.oss_bucket is not None:
             return self.oss_bucket
         self.oss_bucket = oss2.Bucket(self.auth, self.oss_endpoint_url, bucket)
@@ -52,8 +75,7 @@ class AliyunOssArtifactRepository(ArtifactRepository):
         (bucket, dest_path) = self.parse_oss_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
-        dest_path = posixpath.join(
-            dest_path, os.path.basename(local_file))
+        dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         self._get_oss_bucket(bucket)
         self.oss_bucket.put_object_from_file(dest_path, local_file)
 
@@ -63,7 +85,7 @@ class AliyunOssArtifactRepository(ArtifactRepository):
             dest_path = posixpath.join(dest_path, artifact_path)
         self._get_oss_bucket(bucket)
         local_dir = os.path.abspath(local_dir)
-        for (root, _, filenames) in os.walk(local_dir):
+        for root, _, filenames in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
                 rel_path = os.path.relpath(root, local_dir)
@@ -71,7 +93,8 @@ class AliyunOssArtifactRepository(ArtifactRepository):
                 upload_path = posixpath.join(dest_path, rel_path)
             for f in filenames:
                 self.oss_bucket.put_object_from_file(
-                        posixpath.join(upload_path, f), os.path.join(root, f))
+                    posixpath.join(upload_path, f), os.path.join(root, f)
+                )
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = self.parse_oss_uri(self.artifact_uri)
@@ -81,13 +104,14 @@ class AliyunOssArtifactRepository(ArtifactRepository):
         infos = []
         prefix = dest_path + "/" if dest_path else ""
         self._get_oss_bucket(bucket)
-        results = self.oss_bucket.list_objects(prefix=prefix, delimiter='/')
+        results = self.oss_bucket.list_objects(prefix=prefix, delimiter="/")
 
         for obj in results.object_list:
             # is file
             file_path = obj.key
             self._verify_listed_object_contains_artifact_path_prefix(
-                listed_object_path=file_path, artifact_path=artifact_path)
+                listed_object_path=file_path, artifact_path=artifact_path
+            )
             file_rel_path = posixpath.relpath(path=file_path, start=artifact_path)
             file_size = obj.size
             infos.append(FileInfo(file_rel_path, False, file_size))
@@ -95,19 +119,24 @@ class AliyunOssArtifactRepository(ArtifactRepository):
         for subdir_path in results.prefix_list:
             # is dir
             self._verify_listed_object_contains_artifact_path_prefix(
-                listed_object_path=subdir_path, artifact_path=artifact_path)
+                listed_object_path=subdir_path, artifact_path=artifact_path
+            )
             subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
             infos.append(FileInfo(subdir_rel_path, True, None))
         return sorted(infos, key=lambda f: f.path)
 
     @staticmethod
-    def _verify_listed_object_contains_artifact_path_prefix(listed_object_path, artifact_path):
+    def _verify_listed_object_contains_artifact_path_prefix(
+        listed_object_path, artifact_path
+    ):
         if not listed_object_path.startswith(artifact_path):
             raise MlflowException(
                 "The path of the listed oss object does not begin with the specified"
                 " artifact path. Artifact path: {artifact_path}. Object path:"
                 " {object_path}.".format(
-                    artifact_path=artifact_path, object_path=listed_object_path))
+                    artifact_path=artifact_path, object_path=listed_object_path
+                )
+            )
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, oss_root_path) = self.parse_oss_uri(self.artifact_uri)
@@ -116,4 +145,4 @@ class AliyunOssArtifactRepository(ArtifactRepository):
         self.oss_bucket.get_object_to_file(oss_full_path, local_path)
 
     def delete_artifacts(self, artifact_path=None):
-        raise MlflowException('Not implemented yet')
+        raise MlflowException("Not implemented yet")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='aliyunstoreplugin',
-    version='1.0.0',
+    version='1.1.0',
     description='Plugin that provides Aliyun oss Artifact Store functionality for MLflow',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -15,6 +15,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'mlflow',
+        'alibabacloud_credentials',
         'oss2'
     ],
     entry_points={


### PR DESCRIPTION
Now users can access Object Storage Service (OSS) through the following methods:

- Setting the `MLFLOW_OSS_KEY_ID` and `MLFLOW_OSS_KEY_SECRET` environment variables.
- Utilizing the default credential provider chain, which searches for available credentials, including STS role ARN, OIDC role ARN, among others. For additional details, please visit https://pypi.org/project/alibabacloud-credentials/